### PR TITLE
do not instantiate on import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 type BannerIdType = string
 
 /**
- * Micro library for detect adblock on user page
+ * Micro library for detecting adblock on user page
  *
  * @class AdblockDetector
  */
@@ -73,5 +73,3 @@ export class AdblockDetector {
     }
 
 }
-
-export default new AdblockDetector();


### PR DESCRIPTION
There's a bug that halts execution if `document.body` (DOM) ins't loaded yet. The reason is because import statements execute immediately and for some reason it's instantiating directly `new AdblockDetector();` so this would fix it 

and so running this now makes sense:

```
import { AdblockDetector } from "adblock-detector";
const hasAdBlock = new AdblockDetector().detect();
```